### PR TITLE
Different order of keys in the files generated incorrect result

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -26,9 +26,12 @@ function parseJsonLanguage(json, language) {
 
 function combineJson(jsonFirst, jsonSecond, languages) {
     const newJson = Object.assign(jsonFirst, {});
+
     let keysFirst = Object.keys(jsonFirst);
     let keysSecond = Object.keys(jsonSecond);
+
     const max = keysFirst.length >= keysSecond.length ? keysFirst.length : keysSecond.length;
+
     for (let i = 0; i < max; i++) {
         if(!keysFirst[i]) {
             newJson[keysSecond[i]] = jsonSecond[keysSecond[i]];
@@ -37,23 +40,37 @@ function combineJson(jsonFirst, jsonSecond, languages) {
             jsonSecond[keysFirst[i]] = jsonFirst[keysFirst[i]];
         }
     }
-    keysFirst = Object.keys(jsonFirst);
-    keysSecond = Object.keys(jsonSecond);
+
     const keys = Object.keys(newJson);
+
     for (let i = 0; i < keys.length; i++) {
         const elementFirst = jsonFirst[keys[i]];
-        const elementSecond = jsonSecond[keysSecond[i]];
+
         if (typeof elementFirst === 'object') {
-            const res = combineJson(elementFirst, elementSecond, languages);
-            newJson[keys[i]] = res;
+
+            // the second element is a TAG
+            const elementSecond = jsonSecond[keys[i]];
+
+            if (elementSecond) {
+                const res = combineJson(elementFirst, elementSecond, languages);   
+                newJson[keys[i]] = res;
+            }
+
         } else {
+            
+            // the second element is a language string
+            const elementSecond = jsonSecond[keysSecond[i]];
             newJson[keys[i]] = elementFirst;
             newJson[keysSecond[i]] = elementSecond;
+
             const lang = languages.filter(language => !keys.includes(language) && !keysSecond.includes(language));
+
             const res = includeLang(lang);
+
             if(Object.keys(res).length > 0) {
                 Object.assign(newJson, res); 
             }
+
         }
     }
     return newJson;


### PR DESCRIPTION
Hi,

This pull request fixes a problem where keys where being merged based on their order rather than the key itself, mixing them in the case keys where not equally ordered.

As an example, if the language files structure where like these, with the same keys ordered differently:

```
// en.json
{
    "TEST_1": {
        "TEST_1_1": "TEST_1_1",
        "TEST_1_2": "TEST_1_2",
        "TEST_1_3": "TEST_1_3"
    }
}

// eu.json
{
    "TEST_1": {
        "TEST_1_3": "TEST_1_3",
        "TEST_1_2": "TEST_1_2",
        "TEST_1_1": "TEST_1_1"
    }
}
```
The end result would end up like this, mixing the order up even if the keys where the same.

```
// end result
{
    "TEST_1": {
        "TEST_1_1": {
            "en": "TEST_1_1",
            "es": "TEST_1_3"
        },
        "TEST_1_2": {
            "en": "TEST_1_2",
            "es": "TEST_1_2"
        },
        "TEST_1_3": {
            "en": "TEST_1_3",
            "es": "TEST_1_1"
        }
    }
}
```
While with this change the result is:
```
{
    "TEST_1": {
        "TEST_1_1": {
            "en": "TEST_1_1",
            "es": "TEST_1_1"
        },
        "TEST_1_2": {
            "en": "TEST_1_2",
            "es": "TEST_1_2"
        },
        "TEST_1_3": {
            "en": "TEST_1_3",
            "es": "TEST_1_3"
        }
    }
}
```

Thank you for the great work.